### PR TITLE
feat: descriptions for all data sources, resources and attributes

### DIFF
--- a/internal/provider/app_data_source.go
+++ b/internal/provider/app_data_source.go
@@ -32,8 +32,7 @@ func (d *AppDataSource) Metadata(ctx context.Context, req datasource.MetadataReq
 
 func (d *AppDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "`nuon_app` provides information about a Nuon app.\nThis data source can be useful when adding components and installs to an app created in the UI.",
-
+		Description: "Provides information about a Nuon app.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
 				Description: "The human readable name of the app.",

--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -39,16 +39,16 @@ func (r *AppResource) Metadata(ctx context.Context, req resource.MetadataRequest
 
 func (r *AppResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Application",
+		Description: "A Nuon application, required to set up components and installs.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Name of the application.",
+				MarkdownDescription: "The human readable name of the app.",
 				Optional:            false,
 				Required:            true,
 			},
 			"id": schema.StringAttribute{
 				Computed:            true,
-				MarkdownDescription: "ID of the app",
+				MarkdownDescription: "The unique ID of the app",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -61,65 +61,63 @@ func (r *ContainerImageComponentResource) Metadata(ctx context.Context, req reso
 
 func (r *ContainerImageComponentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Container images are used to connect any Docker, ECR or OCI compatible image to your app.",
+		Description: "Use a Docker, ECR or OCI compatible image as a component.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "Component id",
-				Computed:            true,
+				Description: "The unique ID of the component.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Component name",
-				Optional:            false,
-				Required:            true,
+				Description: "The human-readable name of the component.",
+				Optional:    false,
+				Required:    true,
 			},
 			"app_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the app this component belongs too.",
-				Optional:            false,
-				Required:            true,
+				Description: "The unique ID of the app this component belongs too.",
+				Optional:    false,
+				Required:    true,
 			},
 			"sync_only": schema.BoolAttribute{
-				MarkdownDescription: "Set to true to only use this image for syncing (ie: no deployment).",
-				Optional:            true,
-				Required:            false,
+				Description: "If true, this component will be synced to install registries, but not released.",
+				Optional:    true,
+				Required:    false,
 			},
-
-			// public
 			"public": schema.SingleNestedAttribute{
-				Description: "any public, Docker or oci image",
+				Description: "Use a publically-accessible image.",
 				Optional:    true,
 				Attributes: map[string]schema.Attribute{
 					"image_url": schema.StringAttribute{
-						MarkdownDescription: "full image url, or docker hub alias (kennethreitz/httpbin)",
-						Required:            true,
+						Description: "The full image URL or docker hub alias (e.g. kennethreitz/httpbin).",
+						Required:    true,
 					},
 					"tag": schema.StringAttribute{
-						MarkdownDescription: "tag",
-						Required:            true,
+						Description: "The image tag.",
+						Required:    true,
 					},
 				},
 			},
 			"aws_ecr": schema.SingleNestedAttribute{
 				Optional:    true,
-				Description: "any image stored in ECR, with an IAM role that your org can assume.",
+				Description: "Use an image stored in AWS ECR.",
 				Attributes: map[string]schema.Attribute{
-					"region": schema.StringAttribute{
-						MarkdownDescription: "ECR region",
-						Required:            true,
+					"image_url": schema.StringAttribute{
+						Description: "The full URL of your ECR repo.",
+						Required:    true,
 					},
 					"tag": schema.StringAttribute{
-						MarkdownDescription: "tag",
-						Required:            true,
+						Description: "The image tag.",
+						Required:    true,
 					},
-					"image_url": schema.StringAttribute{
-						MarkdownDescription: "image_url",
-						Required:            true,
+					"region": schema.StringAttribute{
+						Description: "The region of your ECR repo.",
+						Required:    true,
 					},
 					"iam_role_arn": schema.StringAttribute{
-						MarkdownDescription: "iam_role_arn",
-						Required:            true,
+						Description: "The AWS IAM role needed to access your ECR repo.",
+						Required:    true,
 					},
 				},
 			},

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -49,36 +49,36 @@ func (r *DockerBuildComponentResource) Metadata(ctx context.Context, req resourc
 
 func (r *DockerBuildComponentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Build any image in a connected or public github repo.",
+		Description: "Build and release any image in a connected or public github repo.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "ID",
-				Computed:            true,
-				Required:            false,
+				Description: "The unique ID of the component.",
+				Computed:    true,
+				Required:    false,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Component name",
-				Optional:            false,
-				Required:            true,
+				Description: "The human-readable name of the component.",
+				Optional:    false,
+				Required:    true,
 			},
 			"app_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the app this component belongs too.",
-				Optional:            false,
-				Required:            true,
+				Description: "The unique ID of the app this component belongs too.",
+				Optional:    false,
+				Required:    true,
 			},
 			"sync_only": schema.BoolAttribute{
-				MarkdownDescription: "Set to true to only use this image for syncing (ie: no deployment).",
-				Optional:            true,
-				Required:            false,
+				Description: "If true, this component will be synced to install registries, but not released.",
+				Optional:    true,
+				Required:    false,
 			},
 			"dockerfile": schema.StringAttribute{
-				MarkdownDescription: "dockerfile",
-				Optional:            true,
-				Default:             stringdefault.StaticString("Dockerfile"),
-				Computed:            true,
+				Description: "The Dockerfile to build from.",
+				Optional:    true,
+				Default:     stringdefault.StaticString("Dockerfile"),
+				Computed:    true,
 			},
 			"public_repo":    publicRepoAttribute(),
 			"connected_repo": connectedRepoAttribute(),

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -27,6 +27,11 @@ type HelmChartComponentResource struct {
 	baseResource
 }
 
+type HelmValue struct {
+	Name  types.String `tfsdk:"name"`
+	Value types.String `tfsdk:"value"`
+}
+
 // HelmChartComponentResourceModel describes the resource data model.
 type HelmChartComponentResourceModel struct {
 	ID types.String `tfsdk:"id"`
@@ -47,29 +52,29 @@ func (r *HelmChartComponentResource) Metadata(ctx context.Context, req resource.
 
 func (r *HelmChartComponentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Deploy any helm chart",
+		Description: "Release a helm chart.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "Component id",
-				Computed:            true,
+				Description: "The unique ID of the component.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Component name",
-				Optional:            false,
-				Required:            true,
+				Description: "The human-readable name of the component.",
+				Optional:    false,
+				Required:    true,
 			},
 			"app_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the app this component belongs too.",
-				Optional:            false,
-				Required:            true,
+				Description: "The unique ID of the app this component belongs too.",
+				Optional:    false,
+				Required:    true,
 			},
 			"chart_name": schema.StringAttribute{
-				MarkdownDescription: "Name that the chart will get installed as.",
-				Optional:            false,
-				Required:            true,
+				Description: "The name to install the chart with.",
+				Optional:    false,
+				Required:    true,
 			},
 			"public_repo":    publicRepoAttribute(),
 			"connected_repo": connectedRepoAttribute(),

--- a/internal/provider/component_terraform_module_resource.go
+++ b/internal/provider/component_terraform_module_resource.go
@@ -46,30 +46,30 @@ func (r *TerraformModuleComponentResource) Metadata(ctx context.Context, req res
 
 func (r *TerraformModuleComponentResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Deploy a terraform module in a public connected repo.",
+		Description: "Release a terraform module.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "Component id",
-				Computed:            true,
+				Description: "The unique ID of the component.",
+				Computed:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Component name",
-				Optional:            false,
-				Required:            true,
+				Description: "The human-readable name of the component.",
+				Optional:    false,
+				Required:    true,
 			},
 			"app_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the app this component belongs too.",
-				Optional:            false,
-				Required:            true,
+				Description: "The unique ID of the app this component belongs too.",
+				Optional:    false,
+				Required:    true,
 			},
 			"terraform_version": schema.StringAttribute{
-				MarkdownDescription: "Terraform version to run as.",
-				Optional:            true,
-				Default:             stringdefault.StaticString("1.5.3"),
-				Computed:            true,
+				Description: "The version of Terraform to use.",
+				Optional:    true,
+				Default:     stringdefault.StaticString("1.5.3"),
+				Computed:    true,
 			},
 			"public_repo":    publicRepoAttribute(),
 			"connected_repo": connectedRepoAttribute(),

--- a/internal/provider/connected_repo_data_source.go
+++ b/internal/provider/connected_repo_data_source.go
@@ -43,24 +43,28 @@ func (d *ConnectedRepoDataSource) Schema(ctx context.Context, req datasource.Sch
 		Description: "Get a connected repo tied to your org.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				Description: "Name or URL of connected repo",
+				Description: "The name or URL of the connected repo",
 				Required:    true,
 			},
 			"default_branch": schema.StringAttribute{
-				Computed: true,
+				Description: "The default branch of the repo.",
+				Computed:    true,
 			},
 			"full_name": schema.StringAttribute{
-				Computed: true,
+				Description: "The full name of the repo.",
+				Computed:    true,
 			},
 			"repo": schema.StringAttribute{
-				Description: "this is the attribute to link to a connected config",
+				Description: "The name of the repo.",
 				Computed:    true,
 			},
 			"owner": schema.StringAttribute{
-				Computed: true,
+				Description: "The owner of the repo.",
+				Computed:    true,
 			},
 			"url": schema.StringAttribute{
-				Computed: true,
+				Description: "The URL of the repo.",
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/install_data_source.go
+++ b/internal/provider/install_data_source.go
@@ -31,19 +31,16 @@ func (d *InstallDataSource) Metadata(ctx context.Context, req datasource.Metadat
 
 func (d *InstallDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description:         "`nuon_install` provides information about a Nuon install.\nThis data source can be useful when adding components and installs to an install created in the UI.",
-		MarkdownDescription: "`nuon_install` provides information about a Nuon install.\nThis data source can be useful when adding components and installs to an install created in the UI.",
+		Description: "Provides information about a Nuon install. This data source can be useful if you need to begin programmatically managing an install created in the UI.",
 
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				Description:         "install name",
-				MarkdownDescription: "install name",
-				Optional:            true,
+				Description: "The human-readable name of the install.",
+				Optional:    true,
 			},
 			"id": schema.StringAttribute{
-				Description:         "Install id",
-				MarkdownDescription: "Install id",
-				Optional:            true,
+				Description: "The unique ID of the install.",
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/install_resource.go
+++ b/internal/provider/install_resource.go
@@ -46,40 +46,40 @@ func (r *InstallResource) Metadata(ctx context.Context, req resource.MetadataReq
 
 func (r *InstallResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Install",
+		Description: "Create an install to release an app to.",
 		Attributes: map[string]schema.Attribute{
 			"name": schema.StringAttribute{
-				MarkdownDescription: "Name of the application.",
-				Optional:            false,
-				Required:            true,
+				Description: "The unique ID of the install.",
+				Optional:    false,
+				Required:    true,
 			},
 			"app_id": schema.StringAttribute{
-				MarkdownDescription: "ID of the app this install belongs too.",
-				Optional:            false,
-				Required:            true,
+				Description: "The human-readable name of the install.",
+				Optional:    false,
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"region": schema.StringAttribute{
-				MarkdownDescription: "AWS region",
-				Optional:            false,
-				Required:            true,
+				Description: "The AWS region to create in the install in.",
+				Optional:    false,
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"iam_role_arn": schema.StringAttribute{
-				MarkdownDescription: "ARN of the role to use for provisioning.",
-				Optional:            false,
-				Required:            true,
+				Description: "The ARN of the AWS IAM role to provision the install with.",
+				Optional:    false,
+				Required:    true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"id": schema.StringAttribute{
-				Computed:            true,
-				MarkdownDescription: "ID of the install",
+				Computed:    true,
+				Description: "The unique ID of the install",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -56,16 +56,16 @@ func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp 
 		Description: "A Terraform provider for managing apps on the Nuon platform.",
 		Attributes: map[string]schema.Attribute{
 			"api_url": schema.StringAttribute{
-				MarkdownDescription: "Override the url to use a custom endpoint.",
-				Optional:            true,
+				Description: "Override the API url to use a custom endpoint.",
+				Optional:    true,
 			},
 			"api_token": schema.StringAttribute{
-				MarkdownDescription: "API token to access the api.",
-				Optional:            true,
+				Description: "A valid API token to access the api.",
+				Optional:    true,
 			},
 			"org_id": schema.StringAttribute{
-				MarkdownDescription: "Nuon org ID.",
-				Optional:            true,
+				Description: "Your Nuon organization ID.",
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/shared_attributes.go
+++ b/internal/provider/shared_attributes.go
@@ -15,20 +15,20 @@ type PublicRepo struct {
 
 func publicRepoAttribute() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		Description: "any public git/github repo",
+		Description: "A publically-accessible git repo.",
 		Optional:    true,
 		Attributes: map[string]schema.Attribute{
 			"repo": schema.StringAttribute{
-				MarkdownDescription: "Public https: clone url  (eg: https://github.com/jonmorehouse/go-httpbin.git)",
-				Required:            true,
+				Description: "The https clone url",
+				Required:    true,
 			},
 			"branch": schema.StringAttribute{
-				MarkdownDescription: "Default branch to create new builds from.",
-				Required:            true,
+				Description: "The default branch to create new builds from.",
+				Required:    true,
 			},
 			"directory": schema.StringAttribute{
-				MarkdownDescription: "Directory",
-				Optional:            true,
+				Description: "The directory the component code is in.",
+				Optional:    true,
 			},
 		},
 	}
@@ -42,20 +42,20 @@ type ConnectedRepo struct {
 
 func connectedRepoAttribute() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{
-		Description: "Repo accessible via your Nuon connected github account",
+		Description: "A repo accessible via your Nuon connected github account",
 		Optional:    true,
 		Attributes: map[string]schema.Attribute{
 			"repo": schema.StringAttribute{
-				MarkdownDescription: "Public https: clone url  (eg: https://github.com/jonmorehouse/go-httpbin.git)",
-				Required:            true,
+				Description: "The https clone url",
+				Required:    true,
 			},
 			"branch": schema.StringAttribute{
-				MarkdownDescription: "Default branch to create new builds from.",
-				Required:            true,
+				Description: "The default branch to create new builds from.",
+				Required:    true,
 			},
 			"directory": schema.StringAttribute{
-				MarkdownDescription: "Static git ref to create new builds from.",
-				Optional:            true,
+				Description: "The directory the component code is in.",
+				Optional:    true,
 			},
 		},
 	}
@@ -73,20 +73,20 @@ func basicDeployAttribute() schema.SingleNestedAttribute {
 		Description: "Create a basic deployment of this image with a listener.",
 		Attributes: map[string]schema.Attribute{
 			"port": schema.Int64Attribute{
-				MarkdownDescription: "Listen port",
-				Required:            true,
+				Description: "The port to listen on.",
+				Required:    true,
 			},
 			"instance_count": schema.Int64Attribute{
-				MarkdownDescription: "Number of instances to run",
-				Default:             int64default.StaticInt64(1),
-				Optional:            true,
-				Computed:            true,
+				Description: "The number of instances to run.",
+				Default:     int64default.StaticInt64(1),
+				Optional:    true,
+				Computed:    true,
 			},
 			"health_check_path": schema.StringAttribute{
-				MarkdownDescription: "image_url",
-				Optional:            true,
-				Default:             stringdefault.StaticString("/"),
-				Computed:            true,
+				Description: "The path to use for health checks.",
+				Optional:    true,
+				Default:     stringdefault.StaticString("/"),
+				Computed:    true,
 			},
 		},
 	}

--- a/internal/provider/shared_blocks.go
+++ b/internal/provider/shared_blocks.go
@@ -12,37 +12,34 @@ type EnvVar struct {
 
 func envVarSharedBlock() schema.ListNestedBlock {
 	return schema.ListNestedBlock{
+		Description: "Environment variables to export into the env when running the image.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"name": schema.StringAttribute{
-					MarkdownDescription: "env var key",
-					Required:            true,
+					Description: "The variable name to export to the env (e.g. API_TOKEN or PORT.)",
+					Required:    true,
 				},
 				"value": schema.StringAttribute{
-					MarkdownDescription: "Value - can be interpolated from any nuon value",
-					Required:            true,
+					Description: "The variable value to export to the env. Can be any valid env var value, or interpolated from Nuon.",
+					Required:    true,
 				},
 			},
 		},
 	}
 }
 
-type HelmValue struct {
-	Name  types.String `tfsdk:"name"`
-	Value types.String `tfsdk:"value"`
-}
-
 func helmValueSharedBlock() schema.ListNestedBlock {
 	return schema.ListNestedBlock{
+		Description: "Helm values to set when deploying the Helm chart.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"name": schema.StringAttribute{
-					MarkdownDescription: "helm values to set, such as `env.secret` or `server.container.image`",
-					Required:            true,
+					Description: "The name of the value to set in the chart (e.g. env.secret or server.container.image.)",
+					Required:    true,
 				},
 				"value": schema.StringAttribute{
-					MarkdownDescription: "Value - can be interpolated from any nuon value",
-					Required:            true,
+					Description: "The value to set in the chart. Can be any valid Helm chart value, or interpolated from Nuon.",
+					Required:    true,
 				},
 			},
 		},
@@ -56,15 +53,16 @@ type TerraformVariable struct {
 
 func terraformVariableSharedBlock() schema.ListNestedBlock {
 	return schema.ListNestedBlock{
+		Description: "Terraform variables to set when applying the Terraform configuration.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				"name": schema.StringAttribute{
-					MarkdownDescription: "Terraform variable to get set. By default is rendered into a tfvars file in the run",
-					Required:            true,
+					Description: "The variable name to write to the terraform.tfvars file (e.g. bucket_name or db_name.)",
+					Required:    true,
 				},
 				"value": schema.StringAttribute{
-					MarkdownDescription: "Value - can be interpolated from any nuon value",
-					Required:            true,
+					Description: "The variable value to write to the terraform.tfvars file. Can be any valid Terraform value, or interpolated from Nuon.",
+					Required:    true,
 				},
 			},
 		},


### PR DESCRIPTION
Setting the `Description` field on all data sources, resources and attributes. This field is meant to be used by dev tooling.

In the absence of the `MarkdownDescription` field, `Description` will also be used to generate documentation for the Terraform registry. This is good enough to get started, but I'll add `MarkdownDescription` for data sources and resources in a following PR to provide more comprehensive usage documention.