### PR TITLE
fix: tests handle unique app names

### DIFF
--- a/internal/provider/component_container_image_resource_test.go
+++ b/internal/provider/component_container_image_resource_test.go
@@ -9,33 +9,37 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccComponentContainerImageResource(args ContainerImageComponentResourceModel) string {
+func testAccComponentContainerImageResource(app AppResourceModel, component ContainerImageComponentResourceModel) string {
 	return fmt.Sprintf(providerConfig+`
 resource "nuon_app" "my_app" {
-    name = "My App"
+    name = %s
 }
 
 resource "nuon_container_image_component" "my_component" {
     app_id = nuon_app.my_app.id
-    name = "%s"
+    name = %s
     sync_only = %v
 
     public = {
-        image_url = "%s"
-        tag = "%s"
+        image_url = %s
+        tag = %s
     }
 
 }
 `,
-		args.Name.ValueString(),
-		args.SyncOnly.ValueBool(),
-		args.Public.ImageURL.ValueString(),
-		args.Public.Tag.ValueString(),
+		app.Name,
+		component.Name,
+		component.SyncOnly,
+		component.Public.ImageURL,
+		component.Public.Tag,
 	)
 }
 
 func TestComponentContainerImageResource(t *testing.T) {
-	createArgs := ContainerImageComponentResourceModel{
+	app := AppResourceModel{
+		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+	}
+	component := ContainerImageComponentResourceModel{
 		Name:        types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		SyncOnly:    types.BoolValue(true),
 		BasicDeploy: nil,
@@ -47,13 +51,13 @@ func TestComponentContainerImageResource(t *testing.T) {
 		EnvVar: []EnvVar{},
 	}
 
-	updateArgs := ContainerImageComponentResourceModel{
+	updatedComponent := ContainerImageComponentResourceModel{
 		Name:        types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-		SyncOnly:    createArgs.SyncOnly,
-		BasicDeploy: createArgs.BasicDeploy,
-		AwsEcr:      createArgs.AwsEcr,
-		Public:      createArgs.Public,
-		EnvVar:      createArgs.EnvVar,
+		SyncOnly:    component.SyncOnly,
+		BasicDeploy: component.BasicDeploy,
+		AwsEcr:      component.AwsEcr,
+		Public:      component.Public,
+		EnvVar:      component.EnvVar,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -61,12 +65,12 @@ func TestComponentContainerImageResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccComponentContainerImageResource(createArgs),
+				Config: testAccComponentContainerImageResource(app, component),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "name", createArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "sync_only", createArgs.SyncOnly.String()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.image_url", createArgs.Public.ImageURL.ValueString()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.tag", createArgs.Public.Tag.ValueString()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "name", component.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "sync_only", component.SyncOnly.String()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.image_url", component.Public.ImageURL.ValueString()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.tag", component.Public.Tag.ValueString()),
 				),
 			},
 			// Import State
@@ -77,12 +81,12 @@ func TestComponentContainerImageResource(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccComponentContainerImageResource(updateArgs),
+				Config: testAccComponentContainerImageResource(app, updatedComponent),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "name", updateArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "sync_only", updateArgs.SyncOnly.String()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.image_url", updateArgs.Public.ImageURL.ValueString()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.tag", updateArgs.Public.Tag.ValueString()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "name", updatedComponent.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "sync_only", updatedComponent.SyncOnly.String()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.image_url", updatedComponent.Public.ImageURL.ValueString()),
+					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.tag", updatedComponent.Public.Tag.ValueString()),
 				),
 			},
 			// Delete testing will happen automatically.

--- a/internal/provider/component_docker_build_resource_test.go
+++ b/internal/provider/component_docker_build_resource_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccComponentDockerBuildResource(args DockerBuildComponentResourceModel) string {
+func testAccComponentDockerBuildResource(app AppResourceModel, component DockerBuildComponentResourceModel) string {
 	return fmt.Sprintf(providerConfig+`
 resource "nuon_app" "my_app" {
-    name = "My App"
+    name = %s
 }
 
 resource "nuon_docker_build_component" "my_component" {
@@ -28,17 +28,21 @@ resource "nuon_docker_build_component" "my_component" {
     }
 }
 `,
-		args.Name,
-		args.SyncOnly,
-		args.Dockerfile,
-		args.PublicRepo.Repo,
-		args.PublicRepo.Directory,
-		args.PublicRepo.Branch,
+		app.Name,
+		component.Name,
+		component.SyncOnly,
+		component.Dockerfile,
+		component.PublicRepo.Repo,
+		component.PublicRepo.Directory,
+		component.PublicRepo.Branch,
 	)
 }
 
 func TestComponentDockerBuildResource(t *testing.T) {
-	createArgs := DockerBuildComponentResourceModel{
+	app := AppResourceModel{
+		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+	}
+	component := DockerBuildComponentResourceModel{
 		Name:       types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		SyncOnly:   types.BoolValue(true),
 		Dockerfile: types.StringValue("Dockerfile"),
@@ -52,7 +56,7 @@ func TestComponentDockerBuildResource(t *testing.T) {
 		EnvVar:        []EnvVar{},
 	}
 
-	updateArgs := DockerBuildComponentResourceModel{
+	updatedComponent := DockerBuildComponentResourceModel{
 		Name:       types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		SyncOnly:   types.BoolValue(true),
 		Dockerfile: types.StringValue("Dockerfile"),
@@ -71,13 +75,13 @@ func TestComponentDockerBuildResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccComponentDockerBuildResource(createArgs),
+				Config: testAccComponentDockerBuildResource(app, component),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "name", createArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "sync_only", createArgs.SyncOnly.String()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.repo", createArgs.PublicRepo.Repo.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.directory", createArgs.PublicRepo.Directory.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.branch", createArgs.PublicRepo.Branch.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "name", component.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "sync_only", component.SyncOnly.String()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.repo", component.PublicRepo.Repo.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.directory", component.PublicRepo.Directory.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.branch", component.PublicRepo.Branch.ValueString()),
 				),
 			},
 			// Import State
@@ -88,13 +92,13 @@ func TestComponentDockerBuildResource(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccComponentDockerBuildResource(updateArgs),
+				Config: testAccComponentDockerBuildResource(app, updatedComponent),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "name", updateArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "sync_only", updateArgs.SyncOnly.String()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.repo", updateArgs.PublicRepo.Repo.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.directory", updateArgs.PublicRepo.Directory.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.branch", updateArgs.PublicRepo.Branch.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "name", updatedComponent.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "sync_only", updatedComponent.SyncOnly.String()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.repo", updatedComponent.PublicRepo.Repo.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.directory", updatedComponent.PublicRepo.Directory.ValueString()),
+					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.branch", updatedComponent.PublicRepo.Branch.ValueString()),
 				),
 			},
 			// Delete testing will happen automatically.

--- a/internal/provider/component_helm_chart_resource_test.go
+++ b/internal/provider/component_helm_chart_resource_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccComponentHelmChartResource(args HelmChartComponentResourceModel) string {
+func testAccComponentHelmChartResource(app AppResourceModel, component HelmChartComponentResourceModel) string {
 	return fmt.Sprintf(providerConfig+`
 resource "nuon_app" "my_app" {
-    name = "My App"
+    name = %s
 }
 
 resource "nuon_helm_chart_component" "my_component" {
@@ -27,16 +27,20 @@ resource "nuon_helm_chart_component" "my_component" {
     }
 }
 `,
-		args.Name,
-		args.ChartName,
-		args.PublicRepo.Repo,
-		args.PublicRepo.Branch,
-		args.PublicRepo.Directory,
+		app.Name,
+		component.Name,
+		component.ChartName,
+		component.PublicRepo.Repo,
+		component.PublicRepo.Branch,
+		component.PublicRepo.Directory,
 	)
 }
 
 func TestComponentHelmChartResource(t *testing.T) {
-	createArgs := HelmChartComponentResourceModel{
+	app := AppResourceModel{
+		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+	}
+	component := HelmChartComponentResourceModel{
 		Name:      types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		ChartName: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		PublicRepo: &PublicRepo{
@@ -46,7 +50,7 @@ func TestComponentHelmChartResource(t *testing.T) {
 		},
 	}
 
-	updateArgs := HelmChartComponentResourceModel{
+	updatedComponent := HelmChartComponentResourceModel{
 		Name:      types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		ChartName: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		PublicRepo: &PublicRepo{
@@ -61,13 +65,13 @@ func TestComponentHelmChartResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccComponentHelmChartResource(createArgs),
+				Config: testAccComponentHelmChartResource(app, component),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "name", createArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "chart_name", createArgs.ChartName.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.repo", createArgs.PublicRepo.Repo.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.branch", createArgs.PublicRepo.Branch.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.directory", createArgs.PublicRepo.Directory.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "name", component.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "chart_name", component.ChartName.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.repo", component.PublicRepo.Repo.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.branch", component.PublicRepo.Branch.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.directory", component.PublicRepo.Directory.ValueString()),
 				),
 			},
 			// Import State
@@ -78,13 +82,13 @@ func TestComponentHelmChartResource(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccComponentHelmChartResource(updateArgs),
+				Config: testAccComponentHelmChartResource(app, updatedComponent),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "name", updateArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "chart_name", updateArgs.ChartName.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.repo", updateArgs.PublicRepo.Repo.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.branch", updateArgs.PublicRepo.Branch.ValueString()),
-					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.directory", updateArgs.PublicRepo.Directory.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "name", updatedComponent.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "chart_name", updatedComponent.ChartName.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.repo", updatedComponent.PublicRepo.Repo.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.branch", updatedComponent.PublicRepo.Branch.ValueString()),
+					resource.TestCheckResourceAttr("nuon_helm_chart_component.my_component", "public_repo.directory", updatedComponent.PublicRepo.Directory.ValueString()),
 				),
 			},
 			// Delete testing will happen automatically.

--- a/internal/provider/component_terraform_module_resource_test.go
+++ b/internal/provider/component_terraform_module_resource_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccComponentTerraformModuleResource(args TerraformModuleComponentResourceModel) string {
+func testAccComponentTerraformModuleResource(app AppResourceModel, component TerraformModuleComponentResourceModel) string {
 	return fmt.Sprintf(providerConfig+`
 resource "nuon_app" "my_app" {
-    name = "My App"
+    name = %s
 }
 
 resource "nuon_terraform_module_component" "my_component" {
@@ -26,15 +26,19 @@ resource "nuon_terraform_module_component" "my_component" {
     }
 }
 `,
-		args.Name,
-		args.PublicRepo.Repo,
-		args.PublicRepo.Branch,
-		args.PublicRepo.Directory,
+		app.Name,
+		component.Name,
+		component.PublicRepo.Repo,
+		component.PublicRepo.Branch,
+		component.PublicRepo.Directory,
 	)
 }
 
 func TestComponentTerraformModuleResource(t *testing.T) {
-	createArgs := TerraformModuleComponentResourceModel{
+	app := AppResourceModel{
+		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+	}
+	component := TerraformModuleComponentResourceModel{
 		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		PublicRepo: &PublicRepo{
 			Repo:      types.StringValue("my-github-org/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
@@ -43,7 +47,7 @@ func TestComponentTerraformModuleResource(t *testing.T) {
 		},
 	}
 
-	updateArgs := TerraformModuleComponentResourceModel{
+	updatedComponent := TerraformModuleComponentResourceModel{
 		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		PublicRepo: &PublicRepo{
 			Repo:      types.StringValue("my-github-org/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
@@ -57,12 +61,12 @@ func TestComponentTerraformModuleResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccComponentTerraformModuleResource(createArgs),
+				Config: testAccComponentTerraformModuleResource(app, component),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "name", createArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.repo", createArgs.PublicRepo.Repo.ValueString()),
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.branch", createArgs.PublicRepo.Branch.ValueString()),
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.directory", createArgs.PublicRepo.Directory.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "name", component.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.repo", component.PublicRepo.Repo.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.branch", component.PublicRepo.Branch.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.directory", component.PublicRepo.Directory.ValueString()),
 				),
 			},
 			// Import State
@@ -73,12 +77,12 @@ func TestComponentTerraformModuleResource(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccComponentTerraformModuleResource(updateArgs),
+				Config: testAccComponentTerraformModuleResource(app, updatedComponent),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "name", updateArgs.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.repo", updateArgs.PublicRepo.Repo.ValueString()),
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.branch", updateArgs.PublicRepo.Branch.ValueString()),
-					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.directory", updateArgs.PublicRepo.Directory.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "name", updatedComponent.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.repo", updatedComponent.PublicRepo.Repo.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.branch", updatedComponent.PublicRepo.Branch.ValueString()),
+					resource.TestCheckResourceAttr("nuon_terraform_module_component.my_component", "public_repo.directory", updatedComponent.PublicRepo.Directory.ValueString()),
 				),
 			},
 			// Delete testing will happen automatically.

--- a/internal/provider/install_resource_test.go
+++ b/internal/provider/install_resource_test.go
@@ -4,40 +4,47 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func testAccInstallResource(args ...string) string {
+func testAccInstallResource(app AppResourceModel, install InstallResourceModel) string {
 	return fmt.Sprintf(providerConfig+`
 resource "nuon_app" "my_app" {
-    name = "My App"
+    name = %s
 }
 
 resource "nuon_install" "my_install" {
     app_id = nuon_app.my_app.id
-    name = "%s"
-    region = "%s"
-    iam_role_arn = "%s"
+    name = %s
+    region = %s
+    iam_role_arn = %s
 }
 `,
-		args[0],
-		args[1],
-		args[2],
+		app.Name,
+		install.Name,
+		install.Region,
+		install.IAMRoleARN,
 	)
 }
 
 func TestInstallResource(t *testing.T) {
-	createArgs := []string{
-		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum),
-		"us-west-2",
-		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum),
+	app := AppResourceModel{
+		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+	}
+	install := InstallResourceModel{
+		AppID:      app.Id,
+		Name:       types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		Region:     types.StringValue("us-west-2"),
+		IAMRoleARN: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 	}
 
-	updateArgs := []string{
-		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum),
-		createArgs[1],
-		createArgs[2],
+	updatedInstall := InstallResourceModel{
+		AppID:      app.Id,
+		Name:       types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		Region:     types.StringValue("us-west-2"),
+		IAMRoleARN: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -45,11 +52,11 @@ func TestInstallResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read
 			{
-				Config: testAccInstallResource(createArgs...),
+				Config: testAccInstallResource(app, install),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_install.my_install", "name", createArgs[0]),
-					resource.TestCheckResourceAttr("nuon_install.my_install", "region", createArgs[1]),
-					resource.TestCheckResourceAttr("nuon_install.my_install", "iam_role_arn", createArgs[2]),
+					resource.TestCheckResourceAttr("nuon_install.my_install", "name", install.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_install.my_install", "region", install.Region.ValueString()),
+					resource.TestCheckResourceAttr("nuon_install.my_install", "iam_role_arn", install.IAMRoleARN.ValueString()),
 				),
 			},
 			// Import State
@@ -60,11 +67,11 @@ func TestInstallResource(t *testing.T) {
 			},
 			// Update and Read
 			{
-				Config: testAccInstallResource(updateArgs...),
+				Config: testAccInstallResource(app, updatedInstall),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("nuon_install.my_install", "name", updateArgs[0]),
-					resource.TestCheckResourceAttr("nuon_install.my_install", "region", updateArgs[1]),
-					resource.TestCheckResourceAttr("nuon_install.my_install", "iam_role_arn", updateArgs[2]),
+					resource.TestCheckResourceAttr("nuon_install.my_install", "name", updatedInstall.Name.ValueString()),
+					resource.TestCheckResourceAttr("nuon_install.my_install", "region", updatedInstall.Region.ValueString()),
+					resource.TestCheckResourceAttr("nuon_install.my_install", "iam_role_arn", updatedInstall.IAMRoleARN.ValueString()),
 				),
 			},
 			// Delete testing will happen automatically.


### PR DESCRIPTION
We weren't setting the app name dynamically in non-app tests. Now that the API requires app names to be unique, these were failing.