### PR TITLE
fix: read method for helm and TF correctly sets vars

### DIFF
--- a/internal/provider/component_helm_chart_resource_test.go
+++ b/internal/provider/component_helm_chart_resource_test.go
@@ -25,6 +25,11 @@ resource "nuon_helm_chart_component" "my_component" {
         branch = %s
         directory = %s
     }
+
+    value {
+        name = %s
+        value = %s
+    }
 }
 `,
 		app.Name,
@@ -33,6 +38,8 @@ resource "nuon_helm_chart_component" "my_component" {
 		component.PublicRepo.Repo,
 		component.PublicRepo.Branch,
 		component.PublicRepo.Directory,
+		component.Value[0].Name,
+		component.Value[0].Value,
 	)
 }
 
@@ -44,9 +51,15 @@ func TestComponentHelmChartResource(t *testing.T) {
 		Name:      types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		ChartName: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		PublicRepo: &PublicRepo{
-			Repo:      types.StringValue("my-github-org/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-			Branch:    types.StringValue("foobar"),
+			Repo:      types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+			Branch:    types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 			Directory: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		},
+		Value: []HelmValue{
+			{
+				Name:  types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+				Value: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+			},
 		},
 	}
 
@@ -54,9 +67,15 @@ func TestComponentHelmChartResource(t *testing.T) {
 		Name:      types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		ChartName: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		PublicRepo: &PublicRepo{
-			Repo:      types.StringValue("my-github-org/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+			Repo:      types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 			Branch:    types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 			Directory: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		},
+		Value: []HelmValue{
+			{
+				Name:  types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+				Value: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+			},
 		},
 	}
 

--- a/internal/provider/component_terraform_module_resource_test.go
+++ b/internal/provider/component_terraform_module_resource_test.go
@@ -24,6 +24,11 @@ resource "nuon_terraform_module_component" "my_component" {
         branch = %s
         directory = %s
     }
+
+    var {
+        name = %s
+        value = %s
+    }
 }
 `,
 		app.Name,
@@ -31,6 +36,8 @@ resource "nuon_terraform_module_component" "my_component" {
 		component.PublicRepo.Repo,
 		component.PublicRepo.Branch,
 		component.PublicRepo.Directory,
+		component.Var[0].Name,
+		component.Var[0].Value,
 	)
 }
 
@@ -45,6 +52,12 @@ func TestComponentTerraformModuleResource(t *testing.T) {
 			Branch:    types.StringValue("foobar"),
 			Directory: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 		},
+		Var: []TerraformVariable{
+			{
+				Name:  types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+				Value: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+			},
+		},
 	}
 
 	updatedComponent := TerraformModuleComponentResourceModel{
@@ -53,6 +66,12 @@ func TestComponentTerraformModuleResource(t *testing.T) {
 			Repo:      types.StringValue("my-github-org/" + acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 			Branch:    types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 			Directory: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		},
+		Var: []TerraformVariable{
+			{
+				Name:  types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+				Value: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+			},
 		},
 	}
 


### PR DESCRIPTION
The `Read` method for both the Helm and Terraform resources was appending to the TF model's attribute, instead of overwriting. This lead to the attribute list being doubled, `terraform refresh` seeing a state change when there was none.

The updated tests still fail, but now it's because the variable names and values are somehow being wrapped in extra quotes. Will follow up with a separate PR for that.