### PR TITLE
feat: read nuon config for SDK

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// config holds config values, read from the `~/.nuon` config file and env vars.
+type Config struct {
+	*viper.Viper
+}
+
+// newConfig creates a new config instance.
+func NewConfig() (*Config, error) {
+	// Initialize Config instance
+	cfg := &Config{viper.New()}
+
+	// Read values from config file.
+	cfg.SetConfigType("yaml")
+	cfg.SetConfigName(".nuon")
+	cfg.AddConfigPath("$HOME")
+	if err := cfg.ReadInConfig(); err != nil {
+		// The config file is optional, so we want to ignore "ConfigFileNotFoundError", but return all other errors.
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return nil, err
+		}
+	}
+
+	// Read values from env vars.
+	cfg.SetEnvPrefix("NUON")
+	cfg.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	cfg.AutomaticEnv()
+
+	return cfg, nil
+}


### PR DESCRIPTION
The provider will now read the SDK config from the same config file and env vars that the CLI does, as well as via Terraform vars.

The API URL, being a special override for testing purposes, can only be set via config file or env vars.