### PR TITLE
fix: changing app_id creates new component

### DIFF
--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -79,6 +79,9 @@ func (r *ContainerImageComponentResource) Schema(ctx context.Context, req resour
 				Description: "The unique ID of the app this component belongs too.",
 				Optional:    false,
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"sync_only": schema.BoolAttribute{
 				Description: "If true, this component will be synced to install registries, but not released.",

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -68,6 +68,9 @@ func (r *DockerBuildComponentResource) Schema(ctx context.Context, req resource.
 				Description: "The unique ID of the app this component belongs too.",
 				Optional:    false,
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"sync_only": schema.BoolAttribute{
 				Description: "If true, this component will be synced to install registries, but not released.",

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -70,6 +70,9 @@ func (r *HelmChartComponentResource) Schema(ctx context.Context, req resource.Sc
 				Description: "The unique ID of the app this component belongs too.",
 				Optional:    false,
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"chart_name": schema.StringAttribute{
 				Description: "The name to install the chart with.",

--- a/internal/provider/component_terraform_module_resource.go
+++ b/internal/provider/component_terraform_module_resource.go
@@ -69,6 +69,9 @@ func (r *TerraformModuleComponentResource) Schema(ctx context.Context, req resou
 				Description: "The unique ID of the app this component belongs too.",
 				Optional:    false,
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"terraform_version": schema.StringAttribute{
 				Description: "The version of Terraform to use.",


### PR DESCRIPTION
We didn't have `RequireReplace` set on the the component app_id attributes. Since components belong to an app, changing that attribute means deleting the current component and creating a new one.