### PR TITLE
chore: improve polling for different edge cases

### DIFF
--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/nuonco/nuon-go/models"
 )
 
@@ -116,6 +118,38 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 	// return populated terraform model
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	tflog.Trace(ctx, "successfully created app")
+
+	// poll app to completion status
+	stateConf := &retry.StateChangeConf{
+		Pending: []string{statusQueued, statusProvisioning},
+		Target:  []string{statusActive},
+		Refresh: func() (interface{}, string, error) {
+			tflog.Trace(ctx, "refreshing app status")
+			install, err := r.restClient.GetApp(ctx, appResp.ID)
+			if err != nil {
+				writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "poll status")
+				return nil, "unknown", err
+			}
+			return install.Status, string(install.Status), nil
+		},
+		Timeout:    time.Minute * 20,
+		Delay:      time.Second * 10,
+		MinTimeout: 3 * time.Second,
+	}
+	statusRaw, err := stateConf.WaitForState()
+	if err != nil {
+		writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "get install")
+		return
+	}
+	status, ok := statusRaw.(string)
+	if !ok {
+		writeDiagnosticsErr(ctx, &resp.Diagnostics, fmt.Errorf("invalid app %s status", status), "create app")
+		return
+	}
+	if status != statusActive {
+		writeDiagnosticsErr(ctx, &resp.Diagnostics, fmt.Errorf("status %s", status), "create app")
+		return
+	}
 }
 
 func (r *AppResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -125,12 +125,12 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 		Target:  []string{statusActive},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing app status")
-			install, err := r.restClient.GetApp(ctx, appResp.ID)
+			app, err := r.restClient.GetApp(ctx, appResp.ID)
 			if err != nil {
 				writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "poll status")
 				return nil, "unknown", err
 			}
-			return install.Status, string(install.Status), nil
+			return app.Status, string(app.Status), nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,
@@ -138,7 +138,7 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 	}
 	statusRaw, err := stateConf.WaitForState()
 	if err != nil {
-		writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "get install")
+		writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "get app")
 		return
 	}
 	status, ok := statusRaw.(string)

--- a/internal/provider/install_resource.go
+++ b/internal/provider/install_resource.go
@@ -142,6 +142,10 @@ func (r *InstallResource) Create(ctx context.Context, req resource.CreateRequest
 		writeDiagnosticsErr(ctx, &resp.Diagnostics, fmt.Errorf("invalid install %s", status), "create install")
 		return
 	}
+	if status != statusActive {
+		writeDiagnosticsErr(ctx, &resp.Diagnostics, fmt.Errorf("status %s", status), "create install")
+		return
+	}
 }
 
 func (r *InstallResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {


### PR DESCRIPTION
This change addresses some minor issues I was running into with the provider:

### Bad install status

Before, the polling for an install status would leave things in an ambiguous state if an install failed. This is because the the polling step only considered a few statuses, but didn't seem to update the state accordingly if a status was returned such as error.

### App status

Usually, it takes a few seconds to create an application if the org is active. However, if a terraform is run right after signup the org won't be ready for ~12 minutes as we provision the single tenant infra.

We now poll the status of the app here. By doing this, we remove edge cases where an install might have to wait for the app/org to be ready and time out + makes this more accurate from a state perspective.
