### PR TITLE
chore: handle temporarily unavailable

### DIFF
--- a/internal/provider/api_conversion.go
+++ b/internal/provider/api_conversion.go
@@ -2,25 +2,25 @@ package provider
 
 const (
 	// orgs, apps & installs:
-	statusQueued         = "queued"
-	statusProvisioning   = "provisioning"
-	statusActive         = "active"
-	statusDeleteQueued   = "delete_queued"
-	statusDeprovisioning = "deprovisioning"
+	statusQueued         string = "queued"
+	statusProvisioning   string = "provisioning"
+	statusActive         string = "active"
+	statusDeleteQueued   string = "delete_queued"
+	statusDeprovisioning string = "deprovisioning"
 
 	// local statuses, based on api responses
-	statusNotFound               = "not-found"
-	statusTemporarilyUnavailable = "temporarily-unavailable"
+	statusNotFound               string = "not-found"
+	statusTemporarilyUnavailable string = "temporarily-unavailable"
 
 	// builds:
 	// queued
-	statusPlanning = "planning"
-	statusBuilding = "building"
+	statusPlanning string = "planning"
+	statusBuilding string = "building"
 	// active
 
 	// deploys:
 	// queued
 	// planning
-	statusDeploying = "deploying"
+	statusDeploying string = "deploying"
 	// active
 )

--- a/internal/provider/api_conversion.go
+++ b/internal/provider/api_conversion.go
@@ -8,6 +8,10 @@ const (
 	statusDeleteQueued   = "delete_queued"
 	statusDeprovisioning = "deprovisioning"
 
+	// local statuses, based on api responses
+	statusNotFound               = "not-found"
+	statusTemporarilyUnavailable = "temporarily-unavailable"
+
 	// builds:
 	// queued
 	statusPlanning = "planning"

--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -256,7 +256,7 @@ func (r *AppResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 				return app.Status, app.Status, nil
 			}
 			if nuon.IsNotFound(err) {
-				return nil, statusNotFound, nil
+				return "", statusNotFound, nil
 			}
 
 			logErr(ctx, err, "delete app")

--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -122,7 +122,7 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 
 	// poll app to completion status
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusQueued, statusProvisioning},
+		Pending: []string{statusQueued, statusProvisioning, statusTemporarilyUnavailable},
 		Target:  []string{statusActive},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing app status")
@@ -266,15 +266,10 @@ func (r *AppResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		Delay:      time.Second * 10,
 		MinTimeout: 3 * time.Second,
 	}
-	statusRaw, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	if err != nil {
 		writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "get app")
 		return
-	}
-
-	status, ok := statusRaw.(string)
-	if !ok {
-		writeDiagnosticsErr(ctx, &resp.Diagnostics, fmt.Errorf("invalid app %s", status), "delete app")
 	}
 }
 

--- a/internal/provider/app_resource.go
+++ b/internal/provider/app_resource.go
@@ -127,11 +127,12 @@ func (r *AppResource) Create(ctx context.Context, req resource.CreateRequest, re
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing app status")
 			app, err := r.restClient.GetApp(ctx, appResp.ID)
-			if err != nil {
-				writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "poll status")
-				return nil, "unknown", err
+			if err == nil {
+				return app.Status, app.Status, nil
 			}
-			return app.Status, string(app.Status), nil
+
+			logErr(ctx, err, "create app")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,
@@ -246,16 +247,20 @@ func (r *AppResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning},
-		Target:  []string{""},
+		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing app status")
 			app, err := r.restClient.GetApp(ctx, data.Id.ValueString())
-			if err != nil {
-				return "", "", nil
-			} else {
+			if err == nil {
 				return app.Status, app.Status, nil
 			}
+			if nuon.IsNotFound(err) {
+				return nil, statusNotFound, nil
+			}
+
+			logErr(ctx, err, "delete app")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,

--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -273,7 +273,7 @@ func (r *ContainerImageComponentResource) Delete(ctx context.Context, req resour
 				return cmp.Status, cmp.Status, nil
 			}
 			if nuon.IsNotFound(err) {
-				return nil, statusNotFound, nil
+				return "", statusNotFound, nil
 			}
 
 			logErr(ctx, err, "delete component")

--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -264,16 +264,20 @@ func (r *ContainerImageComponentResource) Delete(ctx context.Context, req resour
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning},
-		Target:  []string{""},
+		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")
 			cmp, err := r.restClient.GetComponent(ctx, data.ID.ValueString())
-			if err != nil {
-				return "", "", nil
+			if err == nil {
+				return cmp.Status, cmp.Status, nil
+			}
+			if nuon.IsNotFound(err) {
+				return nil, statusNotFound, nil
 			}
 
-			return cmp.Status, cmp.Status, nil
+			logErr(ctx, err, "delete component")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -250,16 +250,20 @@ func (r *DockerBuildComponentResource) Delete(ctx context.Context, req resource.
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning},
-		Target:  []string{""},
+		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")
 			cmp, err := r.restClient.GetComponent(ctx, data.ID.ValueString())
-			if err != nil {
-				return "", "", nil
+			if err == nil {
+				return cmp.Status, cmp.Status, nil
+			}
+			if nuon.IsNotFound(err) {
+				return nil, statusNotFound, nil
 			}
 
-			return cmp.Status, cmp.Status, nil
+			logErr(ctx, err, "delete component")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -259,7 +259,7 @@ func (r *DockerBuildComponentResource) Delete(ctx context.Context, req resource.
 				return cmp.Status, cmp.Status, nil
 			}
 			if nuon.IsNotFound(err) {
-				return nil, statusNotFound, nil
+				return "", statusNotFound, nil
 			}
 
 			logErr(ctx, err, "delete component")

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -242,16 +242,20 @@ func (r *HelmChartComponentResource) Delete(ctx context.Context, req resource.De
 	tflog.Trace(ctx, "successfully deleted component")
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning},
-		Target:  []string{""},
+		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")
 			cmp, err := r.restClient.GetComponent(ctx, data.ID.ValueString())
-			if err != nil {
-				return "", "", nil
+			if err == nil {
+				return cmp.Status, cmp.Status, nil
+			}
+			if nuon.IsNotFound(err) {
+				return nil, statusNotFound, nil
 			}
 
-			return cmp.Status, cmp.Status, nil
+			logErr(ctx, err, "delete component")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -251,7 +251,7 @@ func (r *HelmChartComponentResource) Delete(ctx context.Context, req resource.De
 				return cmp.Status, cmp.Status, nil
 			}
 			if nuon.IsNotFound(err) {
-				return nil, statusNotFound, nil
+				return "", statusNotFound, nil
 			}
 
 			logErr(ctx, err, "delete component")

--- a/internal/provider/component_terraform_module_resource.go
+++ b/internal/provider/component_terraform_module_resource.go
@@ -250,7 +250,7 @@ func (r *TerraformModuleComponentResource) Delete(ctx context.Context, req resou
 				return cmp.Status, cmp.Status, nil
 			}
 			if nuon.IsNotFound(err) {
-				return nil, statusNotFound, nil
+				return "", statusNotFound, nil
 			}
 
 			logErr(ctx, err, "delete component")

--- a/internal/provider/component_terraform_module_resource.go
+++ b/internal/provider/component_terraform_module_resource.go
@@ -241,16 +241,20 @@ func (r *TerraformModuleComponentResource) Delete(ctx context.Context, req resou
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning},
-		Target:  []string{""},
+		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")
 			cmp, err := r.restClient.GetComponent(ctx, data.ID.ValueString())
-			if err != nil {
-				return "", "", nil
+			if err == nil {
+				return cmp.Status, cmp.Status, nil
+			}
+			if nuon.IsNotFound(err) {
+				return nil, statusNotFound, nil
 			}
 
-			return cmp.Status, cmp.Status, nil
+			logErr(ctx, err, "delete component")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 20,
 		Delay:      time.Second * 10,

--- a/internal/provider/errs.go
+++ b/internal/provider/errs.go
@@ -15,3 +15,7 @@ func writeDiagnosticsErr(ctx context.Context, diagnostics *diag.Diagnostics, err
 		fmt.Sprintf("Error: %s\nPlease make sure your configuration is correct, and that the auth token has permissions for this org.", err),
 	)
 }
+
+func logErr(ctx context.Context, err error, op string) {
+	tflog.Trace(ctx, fmt.Sprintf("unable to %s: %s", op, err))
+}

--- a/internal/provider/install_resource.go
+++ b/internal/provider/install_resource.go
@@ -232,7 +232,9 @@ func (r *InstallResource) Delete(ctx context.Context, req resource.DeleteRequest
 			if err == nil {
 				return install.Status, install.Status, nil
 			}
+			logErr(ctx, err, "delete install")
 			if nuon.IsNotFound(err) {
+				logErr(ctx, err, "is not found")
 				return nil, statusNotFound, nil
 			}
 
@@ -243,15 +245,10 @@ func (r *InstallResource) Delete(ctx context.Context, req resource.DeleteRequest
 		Delay:      time.Second * 10,
 		MinTimeout: 3 * time.Second,
 	}
-	statusRaw, err := stateConf.WaitForState()
+	_, err = stateConf.WaitForState()
 	if err != nil {
 		writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "get install")
 		return
-	}
-
-	status, ok := statusRaw.(string)
-	if !ok {
-		writeDiagnosticsErr(ctx, &resp.Diagnostics, fmt.Errorf("invalid install %s", status), "create install")
 	}
 }
 

--- a/internal/provider/install_resource.go
+++ b/internal/provider/install_resource.go
@@ -117,16 +117,17 @@ func (r *InstallResource) Create(ctx context.Context, req resource.CreateRequest
 	tflog.Trace(ctx, "successfully created install")
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusQueued, statusProvisioning},
+		Pending: []string{statusQueued, statusProvisioning, statusTemporarilyUnavailable},
 		Target:  []string{statusActive},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing install status")
 			install, err := r.restClient.GetInstall(ctx, installResp.ID)
-			if err != nil {
-				writeDiagnosticsErr(ctx, &resp.Diagnostics, err, "poll status")
-				return nil, "unknown", err
+			if err == nil {
+				return install.Status, install.Status, nil
 			}
-			return install.Status, string(install.Status), nil
+
+			logErr(ctx, err, "create install")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 45,
 		Delay:      time.Second * 10,
@@ -223,16 +224,20 @@ func (r *InstallResource) Delete(ctx context.Context, req resource.DeleteRequest
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning},
-		Target:  []string{""},
+		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing install status")
 			install, err := r.restClient.GetInstall(ctx, data.ID.ValueString())
-			if err != nil {
-				return "", "", nil
-			} else {
+			if err == nil {
 				return install.Status, install.Status, nil
 			}
+			if nuon.IsNotFound(err) {
+				return nil, statusNotFound, nil
+			}
+
+			logErr(ctx, err, "delete install")
+			return statusTemporarilyUnavailable, statusTemporarilyUnavailable, nil
 		},
 		Timeout:    time.Minute * 45,
 		Delay:      time.Second * 10,

--- a/internal/provider/install_resource.go
+++ b/internal/provider/install_resource.go
@@ -234,8 +234,7 @@ func (r *InstallResource) Delete(ctx context.Context, req resource.DeleteRequest
 			}
 			logErr(ctx, err, "delete install")
 			if nuon.IsNotFound(err) {
-				logErr(ctx, err, "is not found")
-				return nil, statusNotFound, nil
+				return "", statusNotFound, nil
 			}
 
 			logErr(ctx, err, "delete install")


### PR DESCRIPTION
@powertoolsdev/team - I ran into an issue locally where I was running `terraform apply`, and my internet cut out briefly. This causes the install to fail immediately, which attempts to recreate it after.

As many things could cause a small outage like this, I have added some more robustness to our polling - we now actually check the errors and are resilient to situations where the api is temporarily unavailable.
