### PR TITLE
chore: update config to use default properly

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,9 @@ func NewConfig(customFilepath string) (*Config, error) {
 	// Set global config values
 	cfg.APIToken = cfg.GetString("api_token")
 	cfg.APIURL = cfg.GetString("api_url")
+	if cfg.APIURL == "" {
+		cfg.APIURL = defaultAPIURL
+	}
 	cfg.OrgID = cfg.GetString("org_id")
 
 	return cfg, nil


### PR DESCRIPTION
Updates the config to use the default API URL when the one found via viper is empty.
