### PR TITLE
fix: preserve state for variables properly

### DIFF
--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -264,7 +264,7 @@ func (r *ContainerImageComponentResource) Delete(ctx context.Context, req resour
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Pending: []string{statusActive, statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
 		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -250,7 +250,7 @@ func (r *DockerBuildComponentResource) Delete(ctx context.Context, req resource.
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Pending: []string{statusActive, statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
 		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -242,7 +242,7 @@ func (r *HelmChartComponentResource) Delete(ctx context.Context, req resource.De
 	tflog.Trace(ctx, "successfully deleted component")
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Pending: []string{statusActive, statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
 		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -86,7 +86,7 @@ func (r *HelmChartComponentResource) Schema(ctx context.Context, req resource.Sc
 			"connected_repo": connectedRepoAttribute(),
 		},
 		Blocks: map[string]schema.Block{
-			"value": schema.ListNestedBlock{
+			"value": schema.SetNestedBlock{
 				Description: "Environment variables to export into the env when running the image.",
 				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{

--- a/internal/provider/component_terraform_module_resource.go
+++ b/internal/provider/component_terraform_module_resource.go
@@ -241,7 +241,7 @@ func (r *TerraformModuleComponentResource) Delete(ctx context.Context, req resou
 	}
 
 	stateConf := &retry.StateChangeConf{
-		Pending: []string{statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
+		Pending: []string{statusActive, statusDeleteQueued, statusDeprovisioning, statusTemporarilyUnavailable},
 		Target:  []string{statusNotFound},
 		Refresh: func() (interface{}, string, error) {
 			tflog.Trace(ctx, "refreshing component status")

--- a/internal/provider/shared_blocks.go
+++ b/internal/provider/shared_blocks.go
@@ -4,8 +4,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 )
 
-func envVarSharedBlock() schema.ListNestedBlock {
-	return schema.ListNestedBlock{
+func envVarSharedBlock() schema.SetNestedBlock {
+	return schema.SetNestedBlock{
 		Description: "Environment variables to export into the env when running the image.",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
This PR includes (primarily) a fix to the issue where the provider _always_ showed changes in component configs, as well as a few other small changes that were causing edge cases:

* components go into active mode temporarily while deleting in the api, causing a race
* fixed an issue where `create_app` was not storing the sandbox properly
