### PR TITLE
chore: remove basic deploy support

### DIFF
--- a/docs/resources/container_image_component.md
+++ b/docs/resources/container_image_component.md
@@ -59,7 +59,6 @@ resource "nuon_container_image_component" "my_component" {
 - `aws_ecr` (Attributes) Use an image stored in AWS ECR. (see [below for nested schema](#nestedatt--aws_ecr))
 - `env_var` (Block Set) Environment variables to export into the env when running the image. (see [below for nested schema](#nestedblock--env_var))
 - `public` (Attributes) Use a publically-accessible image. (see [below for nested schema](#nestedatt--public))
-- `sync_only` (Boolean) If true, this component will be synced to install registries, but not released.
 
 ### Read-Only
 

--- a/docs/resources/container_image_component.md
+++ b/docs/resources/container_image_component.md
@@ -57,7 +57,6 @@ resource "nuon_container_image_component" "my_component" {
 ### Optional
 
 - `aws_ecr` (Attributes) Use an image stored in AWS ECR. (see [below for nested schema](#nestedatt--aws_ecr))
-- `basic_deploy` (Attributes) Create a basic deployment of this image with a listener. (see [below for nested schema](#nestedatt--basic_deploy))
 - `env_var` (Block Set) Environment variables to export into the env when running the image. (see [below for nested schema](#nestedblock--env_var))
 - `public` (Attributes) Use a publically-accessible image. (see [below for nested schema](#nestedatt--public))
 - `sync_only` (Boolean) If true, this component will be synced to install registries, but not released.
@@ -75,19 +74,6 @@ Required:
 - `image_url` (String) The full URL of your ECR repo.
 - `region` (String) The region of your ECR repo.
 - `tag` (String) The image tag.
-
-
-<a id="nestedatt--basic_deploy"></a>
-### Nested Schema for `basic_deploy`
-
-Required:
-
-- `port` (Number) The port to listen on.
-
-Optional:
-
-- `health_check_path` (String) The path to use for health checks.
-- `instance_count` (Number) The number of instances to run.
 
 
 <a id="nestedblock--env_var"></a>

--- a/docs/resources/docker_build_component.md
+++ b/docs/resources/docker_build_component.md
@@ -61,7 +61,6 @@ resource "nuon_docker_build_component" "my_component" {
 
 ### Optional
 
-- `basic_deploy` (Attributes) Create a basic deployment of this image with a listener. (see [below for nested schema](#nestedatt--basic_deploy))
 - `connected_repo` (Attributes) A repo accessible via your Nuon connected github account (see [below for nested schema](#nestedatt--connected_repo))
 - `dockerfile` (String) The Dockerfile to build from.
 - `env_var` (Block Set) Environment variables to export into the env when running the image. (see [below for nested schema](#nestedblock--env_var))
@@ -71,19 +70,6 @@ resource "nuon_docker_build_component" "my_component" {
 ### Read-Only
 
 - `id` (String) The unique ID of the component.
-
-<a id="nestedatt--basic_deploy"></a>
-### Nested Schema for `basic_deploy`
-
-Required:
-
-- `port` (Number) The port to listen on.
-
-Optional:
-
-- `health_check_path` (String) The path to use for health checks.
-- `instance_count` (Number) The number of instances to run.
-
 
 <a id="nestedatt--connected_repo"></a>
 ### Nested Schema for `connected_repo`

--- a/docs/resources/docker_build_component.md
+++ b/docs/resources/docker_build_component.md
@@ -65,7 +65,6 @@ resource "nuon_docker_build_component" "my_component" {
 - `dockerfile` (String) The Dockerfile to build from.
 - `env_var` (Block Set) Environment variables to export into the env when running the image. (see [below for nested schema](#nestedblock--env_var))
 - `public_repo` (Attributes) A publically-accessible git repo. (see [below for nested schema](#nestedatt--public_repo))
-- `sync_only` (Boolean) If true, this component will be synced to install registries, but not released.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nuonco/nuon-go v0.10.1
+	github.com/nuonco/nuon-go v0.10.2
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -418,6 +418,8 @@ github.com/nuonco/nuon-go v0.10.0 h1:nFZDLLIQ1TF6Pe6PsJnwCLOQy1/9upUpMRZ+R9zP8q8
 github.com/nuonco/nuon-go v0.10.0/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
 github.com/nuonco/nuon-go v0.10.1 h1:z2ThuRFHfbdeVp2UsHd5oBRzeTcbbhmQ9gNR3te+Q00=
 github.com/nuonco/nuon-go v0.10.1/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
+github.com/nuonco/nuon-go v0.10.2 h1:JQTL230NRL7f+evlRbzb7ZsgPo1NZwVOUQiW8xfLX7I=
+github.com/nuonco/nuon-go v0.10.2/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -84,11 +84,6 @@ func (r *ContainerImageComponentResource) Schema(ctx context.Context, req resour
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"sync_only": schema.BoolAttribute{
-				Description: "If true, this component will be synced to install registries, but not released.",
-				Optional:    true,
-				Required:    false,
-			},
 			"public": schema.SingleNestedAttribute{
 				Description: "Use a publically-accessible image.",
 				Optional:    true,
@@ -149,9 +144,7 @@ func (r *ContainerImageComponentResource) Create(ctx context.Context, req resour
 	tflog.Trace(ctx, "got ID -- "+compResp.ID)
 	data.ID = types.StringValue(compResp.ID)
 
-	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{
-		SyncOnly: true,
-	}
+	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{}
 	if data.AwsEcr != nil {
 		configRequest.ImageURL = data.AwsEcr.ImageURL.ValueStringPointer()
 		configRequest.Tag = data.AwsEcr.Tag.ValueStringPointer()
@@ -292,9 +285,7 @@ func (r *ContainerImageComponentResource) Update(ctx context.Context, req resour
 		return
 	}
 
-	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{
-		SyncOnly: true,
-	}
+	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{}
 	if data.AwsEcr != nil {
 		configRequest.ImageURL = data.AwsEcr.ImageURL.ValueStringPointer()
 		configRequest.Tag = data.AwsEcr.Tag.ValueStringPointer()

--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -47,11 +47,8 @@ type Public struct {
 type ContainerImageComponentResourceModel struct {
 	ID types.String `tfsdk:"id"`
 
-	Name     types.String `tfsdk:"name"`
-	AppID    types.String `tfsdk:"app_id"`
-	SyncOnly types.Bool   `tfsdk:"sync_only"`
-
-	BasicDeploy *BasicDeploy `tfsdk:"basic_deploy"`
+	Name  types.String `tfsdk:"name"`
+	AppID types.String `tfsdk:"app_id"`
 
 	AwsEcr *AwsEcr `tfsdk:"aws_ecr"`
 	Public *Public `tfsdk:"public"`
@@ -128,7 +125,6 @@ func (r *ContainerImageComponentResource) Schema(ctx context.Context, req resour
 					},
 				},
 			},
-			"basic_deploy": basicDeployAttribute(),
 		},
 		Blocks: map[string]schema.Block{
 			"env_var": envVarSharedBlock(),
@@ -154,9 +150,8 @@ func (r *ContainerImageComponentResource) Create(ctx context.Context, req resour
 	data.ID = types.StringValue(compResp.ID)
 
 	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{
-		BasicDeployConfig: &models.ServiceBasicDeployConfigRequest{},
+		SyncOnly: true,
 	}
-	configRequest.SyncOnly = data.SyncOnly.ValueBool()
 	if data.AwsEcr != nil {
 		configRequest.ImageURL = data.AwsEcr.ImageURL.ValueStringPointer()
 		configRequest.Tag = data.AwsEcr.Tag.ValueStringPointer()
@@ -168,13 +163,7 @@ func (r *ContainerImageComponentResource) Create(ctx context.Context, req resour
 		configRequest.ImageURL = data.Public.ImageURL.ValueStringPointer()
 		configRequest.Tag = data.Public.Tag.ValueStringPointer()
 	}
-	if data.BasicDeploy != nil {
-		configRequest.BasicDeployConfig = &models.ServiceBasicDeployConfigRequest{
-			ListenPort:      data.BasicDeploy.Port.ValueInt64(),
-			InstanceCount:   data.BasicDeploy.InstanceCount.ValueInt64(),
-			HealthCheckPath: data.BasicDeploy.HealthCheckPath.String(),
-		}
-	}
+
 	_, err = r.restClient.CreateExternalImageComponentConfig(ctx, compResp.ID, configRequest)
 	if err != nil {
 		// attempt to cleanup component, that is in broken state and has no config
@@ -221,8 +210,6 @@ func (r *ContainerImageComponentResource) Read(ctx context.Context, req resource
 		return
 	}
 	externalImage := configResp.ExternalImage
-	// TODO: it wants us to set the data.AppID, but we don't get that from the API
-	data.SyncOnly = types.BoolValue(externalImage.SyncOnly)
 	if externalImage.AwsEcrImageConfig != nil {
 		data.AwsEcr = &AwsEcr{
 			ImageURL:   types.StringValue(externalImage.ImageURL),
@@ -235,17 +222,6 @@ func (r *ContainerImageComponentResource) Read(ctx context.Context, req resource
 			ImageURL: types.StringValue(externalImage.ImageURL),
 			Tag:      types.StringValue(externalImage.Tag),
 		}
-	}
-	if externalImage.BasicDeployConfig != nil {
-		// TODO: setting data.BasicDeploy to any value will set it to null,
-		// causing Terraform to see it changed. Obviously this makes no sense,
-		// but I can't figure out why it's doing this, so I'm just commenting this out for now.
-		// This will need to be resolved before production use.
-		// data.BasicDeploy = &BasicDeploy{
-		//	Port:		 types.Int64Value(externalImage.BasicDeployConfig.ListenPort),
-		//	InstanceCount:	 types.Int64Value(externalImage.BasicDeployConfig.InstanceCount),
-		//	HealthCheckPath: types.StringValue(externalImage.BasicDeployConfig.HealthCheckPath),
-		// }
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -317,9 +293,8 @@ func (r *ContainerImageComponentResource) Update(ctx context.Context, req resour
 	}
 
 	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{
-		BasicDeployConfig: &models.ServiceBasicDeployConfigRequest{},
+		SyncOnly: true,
 	}
-	configRequest.SyncOnly = data.SyncOnly.ValueBool()
 	if data.AwsEcr != nil {
 		configRequest.ImageURL = data.AwsEcr.ImageURL.ValueStringPointer()
 		configRequest.Tag = data.AwsEcr.Tag.ValueStringPointer()
@@ -330,13 +305,6 @@ func (r *ContainerImageComponentResource) Update(ctx context.Context, req resour
 	} else {
 		configRequest.ImageURL = data.Public.ImageURL.ValueStringPointer()
 		configRequest.Tag = data.Public.Tag.ValueStringPointer()
-	}
-	if data.BasicDeploy != nil {
-		configRequest.BasicDeployConfig = &models.ServiceBasicDeployConfigRequest{
-			ListenPort:      data.BasicDeploy.Port.ValueInt64(),
-			InstanceCount:   data.BasicDeploy.InstanceCount.ValueInt64(),
-			HealthCheckPath: data.BasicDeploy.HealthCheckPath.String(),
-		}
 	}
 	_, err = r.restClient.CreateExternalImageComponentConfig(ctx, compResp.ID, configRequest)
 	if err != nil {

--- a/internal/provider/component_container_image_resource_test.go
+++ b/internal/provider/component_container_image_resource_test.go
@@ -18,18 +18,16 @@ resource "nuon_app" "my_app" {
 resource "nuon_container_image_component" "my_component" {
     app_id = nuon_app.my_app.id
     name = %s
-    sync_only = %v
 
     public = {
-        image_url = %s
-        tag = %s
+	image_url = %s
+	tag = %s
     }
 
 }
 `,
 		app.Name,
 		component.Name,
-		component.SyncOnly,
 		component.Public.ImageURL,
 		component.Public.Tag,
 	)
@@ -40,10 +38,8 @@ func TestComponentContainerImageResource(t *testing.T) {
 		Name: types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
 	}
 	component := ContainerImageComponentResourceModel{
-		Name:        types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-		SyncOnly:    types.BoolValue(true),
-		BasicDeploy: nil,
-		AwsEcr:      nil,
+		Name:   types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		AwsEcr: nil,
 		Public: &Public{
 			ImageURL: types.StringValue("kennethreitz/httpbin"),
 			Tag:      types.StringValue("latest"),
@@ -52,12 +48,10 @@ func TestComponentContainerImageResource(t *testing.T) {
 	}
 
 	updatedComponent := ContainerImageComponentResourceModel{
-		Name:        types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-		SyncOnly:    component.SyncOnly,
-		BasicDeploy: component.BasicDeploy,
-		AwsEcr:      component.AwsEcr,
-		Public:      component.Public,
-		EnvVar:      component.EnvVar,
+		Name:   types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
+		AwsEcr: component.AwsEcr,
+		Public: component.Public,
+		EnvVar: component.EnvVar,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -68,7 +62,6 @@ func TestComponentContainerImageResource(t *testing.T) {
 				Config: testAccComponentContainerImageResource(app, component),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "name", component.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "sync_only", component.SyncOnly.String()),
 					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.image_url", component.Public.ImageURL.ValueString()),
 					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.tag", component.Public.Tag.ValueString()),
 				),
@@ -84,7 +77,6 @@ func TestComponentContainerImageResource(t *testing.T) {
 				Config: testAccComponentContainerImageResource(app, updatedComponent),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "name", updatedComponent.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "sync_only", updatedComponent.SyncOnly.String()),
 					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.image_url", updatedComponent.Public.ImageURL.ValueString()),
 					resource.TestCheckResourceAttr("nuon_container_image_component.my_component", "public.tag", updatedComponent.Public.Tag.ValueString()),
 				),

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -38,8 +38,7 @@ type DockerBuildComponentResourceModel struct {
 	Name  types.String `tfsdk:"name"`
 	AppID types.String `tfsdk:"app_id"`
 
-	SyncOnly types.Bool `tfsdk:"sync_only"`
-	EnvVar   []EnvVar   `tfsdk:"env_var"`
+	EnvVar []EnvVar `tfsdk:"env_var"`
 
 	Dockerfile    types.String   `tfsdk:"dockerfile"`
 	ConnectedRepo *ConnectedRepo `tfsdk:"connected_repo"`
@@ -74,11 +73,6 @@ func (r *DockerBuildComponentResource) Schema(ctx context.Context, req resource.
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-			},
-			"sync_only": schema.BoolAttribute{
-				Description: "If true, this component will be synced to install registries, but not released.",
-				Optional:    true,
-				Required:    false,
 			},
 			"dockerfile": schema.StringAttribute{
 				Description: "The Dockerfile to build from.",
@@ -115,7 +109,6 @@ func (r *DockerBuildComponentResource) Create(ctx context.Context, req resource.
 	configRequest := &models.ServiceCreateDockerBuildComponentConfigRequest{
 		BuildArgs:  []string{},
 		Dockerfile: data.Dockerfile.ValueString(),
-		SyncOnly:   data.SyncOnly.ValueBool(),
 		Target:     "",
 		EnvVars:    map[string]string{},
 	}
@@ -279,7 +272,6 @@ func (r *DockerBuildComponentResource) Update(ctx context.Context, req resource.
 	configRequest := &models.ServiceCreateDockerBuildComponentConfigRequest{
 		BuildArgs:  []string{},
 		Dockerfile: data.Dockerfile.ValueString(),
-		SyncOnly:   data.SyncOnly.ValueBool(),
 		Target:     "",
 		EnvVars:    map[string]string{},
 	}

--- a/internal/provider/component_docker_build_resource_test.go
+++ b/internal/provider/component_docker_build_resource_test.go
@@ -18,19 +18,17 @@ resource "nuon_app" "my_app" {
 resource "nuon_docker_build_component" "my_component" {
     app_id = nuon_app.my_app.id
     name = %s
-    sync_only = %v
     dockerfile = %s
 
     public_repo = {
-        repo = %s
-        directory = %s
-        branch = %s
+	repo = %s
+	directory = %s
+	branch = %s
     }
 }
 `,
 		app.Name,
 		component.Name,
-		component.SyncOnly,
 		component.Dockerfile,
 		component.PublicRepo.Repo,
 		component.PublicRepo.Directory,
@@ -52,7 +50,6 @@ func TestComponentDockerBuildResource(t *testing.T) {
 			Branch:    types.StringValue("master"),
 		},
 		ConnectedRepo: nil,
-		BasicDeploy:   nil,
 		EnvVar:        []EnvVar{},
 	}
 
@@ -66,7 +63,6 @@ func TestComponentDockerBuildResource(t *testing.T) {
 			Branch:    types.StringValue("master"),
 		},
 		ConnectedRepo: nil,
-		BasicDeploy:   nil,
 		EnvVar:        []EnvVar{},
 	}
 

--- a/internal/provider/component_docker_build_resource_test.go
+++ b/internal/provider/component_docker_build_resource_test.go
@@ -42,7 +42,6 @@ func TestComponentDockerBuildResource(t *testing.T) {
 	}
 	component := DockerBuildComponentResourceModel{
 		Name:       types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-		SyncOnly:   types.BoolValue(true),
 		Dockerfile: types.StringValue("Dockerfile"),
 		PublicRepo: &PublicRepo{
 			Repo:      types.StringValue("https://github.com/postmanlabs/httpbin.git"),
@@ -55,7 +54,6 @@ func TestComponentDockerBuildResource(t *testing.T) {
 
 	updatedComponent := DockerBuildComponentResourceModel{
 		Name:       types.StringValue(acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)),
-		SyncOnly:   types.BoolValue(true),
 		Dockerfile: types.StringValue("Dockerfile"),
 		PublicRepo: &PublicRepo{
 			Repo:      types.StringValue("https://github.com/postmanlabs/httpbin.git"),
@@ -74,7 +72,6 @@ func TestComponentDockerBuildResource(t *testing.T) {
 				Config: testAccComponentDockerBuildResource(app, component),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "name", component.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "sync_only", component.SyncOnly.String()),
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.repo", component.PublicRepo.Repo.ValueString()),
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.directory", component.PublicRepo.Directory.ValueString()),
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.branch", component.PublicRepo.Branch.ValueString()),
@@ -91,7 +88,6 @@ func TestComponentDockerBuildResource(t *testing.T) {
 				Config: testAccComponentDockerBuildResource(app, updatedComponent),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "name", updatedComponent.Name.ValueString()),
-					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "sync_only", updatedComponent.SyncOnly.String()),
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.repo", updatedComponent.PublicRepo.Repo.ValueString()),
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.directory", updatedComponent.PublicRepo.Directory.ValueString()),
 					resource.TestCheckResourceAttr("nuon_docker_build_component.my_component", "public_repo.branch", updatedComponent.PublicRepo.Branch.ValueString()),

--- a/internal/provider/shared_attributes.go
+++ b/internal/provider/shared_attributes.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -56,37 +54,6 @@ func connectedRepoAttribute() schema.SingleNestedAttribute {
 			"directory": schema.StringAttribute{
 				Description: "The directory the component code is in.",
 				Optional:    true,
-			},
-		},
-	}
-}
-
-type BasicDeploy struct {
-	Port            types.Int64  `tfsdk:"port"`
-	InstanceCount   types.Int64  `tfsdk:"instance_count"`
-	HealthCheckPath types.String `tfsdk:"health_check_path"`
-}
-
-func basicDeployAttribute() schema.SingleNestedAttribute {
-	return schema.SingleNestedAttribute{
-		Optional:    true,
-		Description: "Create a basic deployment of this image with a listener.",
-		Attributes: map[string]schema.Attribute{
-			"port": schema.Int64Attribute{
-				Description: "The port to listen on.",
-				Required:    true,
-			},
-			"instance_count": schema.Int64Attribute{
-				Description: "The number of instances to run.",
-				Default:     int64default.StaticInt64(1),
-				Optional:    true,
-				Computed:    true,
-			},
-			"health_check_path": schema.StringAttribute{
-				Description: "The path to use for health checks.",
-				Optional:    true,
-				Default:     stringdefault.StaticString("/"),
-				Computed:    true,
 			},
 		},
 	}


### PR DESCRIPTION
This removes support for basic deploys, which have been superceded by helm/terraform.
