### PR TITLE
feat: add install inputs + some renaming

### DIFF
--- a/docs/resources/app_sandbox.md
+++ b/docs/resources/app_sandbox.md
@@ -24,8 +24,8 @@ Sandbox configuration for an app.
 
 - `builtin_sandbox_release_id` (String) release ID for a built in sandbox to use
 - `connected_repo` (Attributes) A repo accessible via your Nuon connected github account (see [below for nested schema](#nestedatt--connected_repo))
-- `input` (Block Set) default sandbox inputs that will be used on each install. Can use Nuon interpolation language. (see [below for nested schema](#nestedblock--input))
 - `public_repo` (Attributes) A publically-accessible git repo. (see [below for nested schema](#nestedatt--public_repo))
+- `var` (Block Set) default sandbox vars that will be used on each install. Can use Nuon interpolation language. (see [below for nested schema](#nestedblock--var))
 
 ### Read-Only
 
@@ -44,15 +44,6 @@ Optional:
 - `directory` (String) The directory the component code is in.
 
 
-<a id="nestedblock--input"></a>
-### Nested Schema for `input`
-
-Required:
-
-- `name` (String) The input name to be used, which will be used as a terraform variable input to the sandbox.
-- `value` (String) The static value, or interpolate value to set.
-
-
 <a id="nestedatt--public_repo"></a>
 ### Nested Schema for `public_repo`
 
@@ -64,3 +55,12 @@ Required:
 Optional:
 
 - `directory` (String) The directory the component code is in.
+
+
+<a id="nestedblock--var"></a>
+### Nested Schema for `var`
+
+Required:
+
+- `name` (String) The var name to be used, which will be used as a terraform variable input to the sandbox.
+- `value` (String) The static value, or interpolated value to set.

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nuonco/nuon-go v0.10.2
+	github.com/nuonco/nuon-go v0.11.2
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,10 @@ github.com/nuonco/nuon-go v0.10.1 h1:z2ThuRFHfbdeVp2UsHd5oBRzeTcbbhmQ9gNR3te+Q00
 github.com/nuonco/nuon-go v0.10.1/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
 github.com/nuonco/nuon-go v0.10.2 h1:JQTL230NRL7f+evlRbzb7ZsgPo1NZwVOUQiW8xfLX7I=
 github.com/nuonco/nuon-go v0.10.2/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
+github.com/nuonco/nuon-go v0.11.1 h1:LXuVhY0SZQisAL9SWGnj0Zj9IN63BalqI93t3l5jySA=
+github.com/nuonco/nuon-go v0.11.1/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
+github.com/nuonco/nuon-go v0.11.2 h1:EJOdJ4bjMDU7vC0ET1mgR4W7wGOy5NDJQKCyWRva13c=
+github.com/nuonco/nuon-go v0.11.2/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -108,7 +108,7 @@ func (r *DockerBuildComponentResource) Create(ctx context.Context, req resource.
 
 	configRequest := &models.ServiceCreateDockerBuildComponentConfigRequest{
 		BuildArgs:  []string{},
-		Dockerfile: data.Dockerfile.ValueString(),
+		Dockerfile: toPtr(data.Dockerfile.ValueString()),
 		Target:     "",
 		EnvVars:    map[string]string{},
 	}
@@ -271,7 +271,7 @@ func (r *DockerBuildComponentResource) Update(ctx context.Context, req resource.
 
 	configRequest := &models.ServiceCreateDockerBuildComponentConfigRequest{
 		BuildArgs:  []string{},
-		Dockerfile: data.Dockerfile.ValueString(),
+		Dockerfile: toPtr(data.Dockerfile.ValueString()),
 		Target:     "",
 		EnvVars:    map[string]string{},
 	}


### PR DESCRIPTION
This change adds support for install-inputs into the install resource. This allows a vendor to specify inputs for an install managed by terraform.

While in here, renamed the `inputs` field on `app_sandbox_config`, to `var` to be more like a terraform component.
