### PR TITLE
feat: implement component dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/nuonco/nuon-go v0.11.2
+	github.com/nuonco/nuon-go v0.11.4
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -424,6 +424,8 @@ github.com/nuonco/nuon-go v0.11.1 h1:LXuVhY0SZQisAL9SWGnj0Zj9IN63BalqI93t3l5jySA
 github.com/nuonco/nuon-go v0.11.1/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
 github.com/nuonco/nuon-go v0.11.2 h1:EJOdJ4bjMDU7vC0ET1mgR4W7wGOy5NDJQKCyWRva13c=
 github.com/nuonco/nuon-go v0.11.2/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
+github.com/nuonco/nuon-go v0.11.4 h1:3E/ITahlidzb9j+UwesMf9C43s25PnxfWyUQz71dv0s=
+github.com/nuonco/nuon-go v0.11.4/go.mod h1:9hQTXgG2MUXaAtW8SN3X6yiWPs4Z4LcIr+CqhECklGI=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=


### PR DESCRIPTION
This PR adds dependency management into the provider. You can now create a dependency between two components, and Nuon will automatically reconcile which components should be deployed/removed and in which order.
