### PR TITLE
fix: do not set field after writing

### DIFF
--- a/internal/provider/app_installer_resource.go
+++ b/internal/provider/app_installer_resource.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &AppInstallerResource{}
+var _ resource.ResourceWithImportState = &AppInstallerResource{}
+
+func NewAppInstallerResource() resource.Resource {
+	return &AppInstallerResource{}
+}
+
+// AppInstallerResource defines the resource implementation.
+type AppInstallerResource struct {
+	baseResource
+}
+
+// AppInstallerResourceModel describes the resource data model.
+type AppInstallerResourceModel struct {
+	Id types.String `tfsdk:"id"`
+
+	AppID types.String `tfsdk:"app_id"`
+
+	Slug types.String `tfsdk:"slug"`
+
+	// metadata
+	Name        types.String `tfsdk:"name"`
+	Description types.String `tfsdk:"description"`
+
+	PostInstallMarkdown types.String `tfsdk:"post_install_markdown"`
+
+	DocumentationURL types.String `tfsdk:"documentation_url"`
+	HomepageURL      types.String `tfsdk:"homepage_url"`
+	CommunityURL     types.String `tfsdk:"community_url"`
+	GithubURL        types.String `tfsdk:"github_url"`
+	LogoURL          types.String `tfsdk:"logo_url"`
+	DemoURL          types.String `tfsdk:"demo_url"`
+}
+
+func (r *AppInstallerResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_app_installer"
+}
+
+func (r *AppInstallerResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "A public installer page for a nuon app.",
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "App name to render on install page.",
+				Optional:            false,
+				Required:            true,
+			},
+			"description": schema.StringAttribute{
+				MarkdownDescription: "Short description of app.",
+				Optional:            false,
+				Required:            true,
+			},
+			"post_install_markdown": schema.StringAttribute{
+				MarkdownDescription: "Markdown that will be shown to users after a successful install. Supports interpolation.",
+				Optional:            false,
+				Required:            true,
+			},
+			"slug": schema.StringAttribute{
+				MarkdownDescription: "URL slug to access app from.",
+				Optional:            false,
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"documentation_url": schema.StringAttribute{
+				MarkdownDescription: "Documentation url",
+				Optional:            false,
+				Required:            true,
+			},
+			"homepage_url": schema.StringAttribute{
+				MarkdownDescription: "Homepage url",
+				Optional:            false,
+				Required:            true,
+			},
+			"community_url": schema.StringAttribute{
+				MarkdownDescription: "Community url to a slack or discord, etc.",
+				Optional:            false,
+				Required:            true,
+			},
+			"github_url": schema.StringAttribute{
+				MarkdownDescription: "GitHub url, link to application.",
+				Optional:            false,
+				Required:            true,
+			},
+			"logo_url": schema.StringAttribute{
+				MarkdownDescription: "Logo image to display on page.",
+				Optional:            false,
+				Required:            true,
+			},
+			"demo_url": schema.StringAttribute{
+				MarkdownDescription: "Demo url to show",
+				Optional:            true,
+				Required:            false,
+			},
+			"app_id": schema.StringAttribute{
+				Description: "The application ID.",
+				Optional:    false,
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The unique ID of the app.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *AppInstallerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+}
+
+func (r *AppInstallerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+}
+
+func (r *AppInstallerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+}
+
+func (r *AppInstallerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+}
+
+func (r *AppInstallerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	// resource.ImportStatePassthroughID(ctx, path.Root("org_id"), req, resp)
+}

--- a/internal/provider/component_container_image_resource.go
+++ b/internal/provider/component_container_image_resource.go
@@ -167,7 +167,7 @@ func (r *ContainerImageComponentResource) Create(ctx context.Context, req resour
 	tflog.Trace(ctx, "got ID -- "+compResp.ID)
 	data.ID = types.StringValue(compResp.ID)
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{}
 	if data.AwsEcr != nil {
@@ -319,7 +319,7 @@ func (r *ContainerImageComponentResource) Update(ctx context.Context, req resour
 		return
 	}
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateExternalImageComponentConfigRequest{}
 	if data.AwsEcr != nil {

--- a/internal/provider/component_docker_build_resource.go
+++ b/internal/provider/component_docker_build_resource.go
@@ -128,7 +128,7 @@ func (r *DockerBuildComponentResource) Create(ctx context.Context, req resource.
 	tflog.Trace(ctx, "got ID -- "+compResp.ID)
 	data.ID = types.StringValue(compResp.ID)
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateDockerBuildComponentConfigRequest{
 		BuildArgs:  []string{},
@@ -300,7 +300,7 @@ func (r *DockerBuildComponentResource) Update(ctx context.Context, req resource.
 		return
 	}
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateDockerBuildComponentConfigRequest{
 		BuildArgs:  []string{},

--- a/internal/provider/component_helm_chart_resource.go
+++ b/internal/provider/component_helm_chart_resource.go
@@ -162,7 +162,7 @@ func (r *HelmChartComponentResource) Create(ctx context.Context, req resource.Cr
 	tflog.Trace(ctx, "got ID -- "+compResp.ID)
 	data.ID = types.StringValue(compResp.ID)
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateHelmComponentConfigRequest{
 		ChartName:                data.ChartName.ValueStringPointer(),
@@ -357,7 +357,7 @@ func (r *HelmChartComponentResource) Update(ctx context.Context, req resource.Up
 		return
 	}
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateHelmComponentConfigRequest{
 		ChartName:                data.ChartName.ValueStringPointer(),

--- a/internal/provider/component_job_resource.go
+++ b/internal/provider/component_job_resource.go
@@ -135,7 +135,7 @@ func (r *JobComponentResource) Create(ctx context.Context, req resource.CreateRe
 	}
 	tflog.Trace(ctx, "got ID -- "+compResp.ID)
 	data.ID = types.StringValue(compResp.ID)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateJobComponentConfigRequest{
 		ImageURL: data.ImageURL.ValueStringPointer(),
@@ -273,7 +273,7 @@ func (r *JobComponentResource) Update(ctx context.Context, req resource.UpdateRe
 	}
 
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateJobComponentConfigRequest{
 		ImageURL: data.ImageURL.ValueStringPointer(),

--- a/internal/provider/component_terraform_module_resource.go
+++ b/internal/provider/component_terraform_module_resource.go
@@ -148,7 +148,7 @@ func (r *TerraformModuleComponentResource) Create(ctx context.Context, req resou
 	tflog.Trace(ctx, "got ID -- "+compResp.ID)
 	data.ID = types.StringValue(compResp.ID)
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateTerraformModuleComponentConfigRequest{
 		ConnectedGithubVcsConfig: nil,
@@ -340,7 +340,7 @@ func (r *TerraformModuleComponentResource) Update(ctx context.Context, req resou
 		return
 	}
 	data.Name = types.StringValue(compResp.Name)
-	data.VarName = types.StringValue(compResp.VarName)
+	//data.VarName = types.StringValue(compResp.VarName)
 
 	configRequest := &models.ServiceCreateTerraformModuleComponentConfigRequest{
 		ConnectedGithubVcsConfig: nil,

--- a/internal/provider/installer_resource.go
+++ b/internal/provider/installer_resource.go
@@ -31,8 +31,8 @@ type InstallerResource struct {
 	baseResource
 }
 
-// AppInstallerResourceModel describes the resource data model.
-type AppInstallerResourceModel struct {
+// InstallerResourceModel describes the resource data model.
+type InstallerResourceModel struct {
 	Id types.String `tfsdk:"id"`
 
 	AppIDs types.Set `tfsdk:"app_ids"`
@@ -143,7 +143,7 @@ func (r *InstallerResource) Schema(ctx context.Context, req resource.SchemaReque
 
 func (r *InstallerResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// get terraform model
-	var data *AppInstallerResourceModel
+	var data *InstallerResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -202,7 +202,7 @@ func (r *InstallerResource) Create(ctx context.Context, req resource.CreateReque
 }
 
 func (r *InstallerResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *AppInstallerResourceModel
+	var data *InstallerResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -255,7 +255,7 @@ func (r *InstallerResource) Read(ctx context.Context, req resource.ReadRequest, 
 
 func (r *InstallerResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// get terraform model
-	var data *AppInstallerResourceModel
+	var data *InstallerResourceModel
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -325,7 +325,7 @@ func (r *InstallerResource) Update(ctx context.Context, req resource.UpdateReque
 }
 
 func (r *InstallerResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *AppInstallerResourceModel
+	var data *InstallerResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -116,6 +116,9 @@ func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
 		NewHelmChartComponentResource,
 		NewTerraformModuleComponentResource,
 		NewJobComponentResource,
+
+		// Deprecated
+		NewAppInstallerResource,
 	}
 }
 


### PR DESCRIPTION
This prevents situations where the API returning an empty string for a nil causes the provider to show an inconsistent response.
